### PR TITLE
Implement changes for esp_hid component

### DIFF
--- a/components/esp_hid/Kconfig
+++ b/components/esp_hid/Kconfig
@@ -1,0 +1,17 @@
+menu "ESP HID"
+    config ESPHID_TASK_SIZE_BTC
+        int "Task stack size for ESP HID BR/EDR"
+        range 2048 10240
+        default 2048
+        help 
+            This is the stack size for the BTC HID task. 
+            Default is 2048 bytes.
+
+    config ESPHID_TASK_SIZE_BLE
+        int "Task stack size for ESP HID BLE"
+        range 2048 10240
+        default 2048
+        help 
+            This is the stack size for the BLE HID task.
+            Default is 2048 bytes.
+endmenu

--- a/components/esp_hid/include/esp_hid_common.h
+++ b/components/esp_hid/include/esp_hid_common.h
@@ -85,6 +85,19 @@ extern "C" {
 #define ESP_HID_CCC_NOTIFICATIONS_ENABLED   0x01      // Notifications enabled
 #define ESP_HID_CCC_INDICATIONS_ENABLED     0x02      // Indications enabled
 
+/* HID Task Size configuration */
+#ifdef  CONFIG_ESPHID_TASK_SIZE_BTC
+#define BT_HID_DEVICE_TASK_SIZE_BTC         CONFIG_ESPHID_TASK_SIZE_BTC
+#else 
+#define BT_HID_DEVICE_TASK_SIZE_BTC         2048
+#endif
+
+#ifdef  CONFIG_ESPHID_TASK_SIZE_BLE
+#define BT_HID_DEVICE_TASK_SIZE_BLE         CONFIG_ESPHID_TASK_SIZE_BLE
+#else 
+#define BT_HID_DEVICE_TASK_SIZE_BLE         2048
+#endif
+
 /* HID Transports */
 typedef enum {
     ESP_HID_TRANSPORT_BT,

--- a/components/esp_hid/src/ble_hidd.c
+++ b/components/esp_hid/src/ble_hidd.c
@@ -971,7 +971,7 @@ esp_err_t esp_ble_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_conf
         .queue_size = 5,
         .task_name = "ble_hidd_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 4096,
+        .task_stack_size = BT_HID_DEVICE_TASK_SIZE_BLE,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &s_dev->event_loop_handle);

--- a/components/esp_hid/src/bt_hidd.c
+++ b/components/esp_hid/src/bt_hidd.c
@@ -809,7 +809,7 @@ esp_err_t esp_bt_hidd_dev_init(esp_hidd_dev_t *dev_p, const esp_hid_device_confi
         .queue_size = 5,
         .task_name = "bt_hidd_events",
         .task_priority = uxTaskPriorityGet(NULL),
-        .task_stack_size = 2048,
+        .task_stack_size = BT_HID_DEVICE_TASK_SIZE_BTC,
         .task_core_id = tskNO_AFFINITY
     };
     ret = esp_event_loop_create(&event_task_args, &s_hidd_param.dev->event_loop_handle);


### PR DESCRIPTION
- Implement Kconfig task size parameters for BLE/BTC tasks
- esp_hid task requires user-defined callbacks, and limiting this with a constant value is generally a bad idea for events that require immediate handling.
