### PR TITLE
feat(bt): Implement SDK Config SDP size options

### DIFF
--- a/components/bt/host/bluedroid/Kconfig.in
+++ b/components/bt/host/bluedroid/Kconfig.in
@@ -132,6 +132,26 @@ config BT_SDP_COMMON_ENABLED
     help
         This enables common SDP operation, such as SDP record creation and deletion.
 
+config BT_SDP_PAD_LEN
+    int "BT SDP attributes allocated length (bytes)"
+    depends on BT_CLASSIC_ENABLED
+    default 300
+    range   300 1024
+    help
+        This is the total size of all SDP attributes allowed. 
+        Any attributes that exceed this size are truncated. 
+        The default value is 300.
+
+config BT_SDP_ATTR_LEN
+    int "BT SDP attribute allocated length (bytes)"
+    depends on BT_CLASSIC_ENABLED
+    default 400
+    range   400 1024
+    help
+        This is the maximum allowed size for a single SDP attribute. 
+        Any attributes that exceed this size are truncated. 
+        The default value is 400.
+
 menuconfig BT_HFP_ENABLE
     bool "Hands Free/Handset Profile"
     depends on BT_CLASSIC_ENABLED

--- a/components/bt/host/bluedroid/common/include/common/bluedroid_user_config.h
+++ b/components/bt/host/bluedroid/common/include/common/bluedroid_user_config.h
@@ -73,6 +73,20 @@
 #define UC_BT_SDP_COMMON_ENABLED            FALSE
 #endif
 
+// SDP Pad Length
+#ifdef CONFIG_BT_SDP_PAD_LEN
+#define UC_SDP_MAX_PAD_LEN                  CONFIG_BT_SDP_PAD_LEN
+#else 
+#define UC_SDP_MAX_PAD_LEN                  300
+#endif
+
+// SDP Max Attribute Length
+#ifdef CONFIG_BT_SDP_ATTR_LEN
+#define UC_SDP_MAX_ATTR_LEN                 CONFIG_BT_SDP_ATTR_LEN
+#else 
+#define UC_SDP_MAX_ATTR_LEN                 400
+#endif
+
 //HFP(AG)
 #ifdef CONFIG_BT_HFP_AG_ENABLE
 #define UC_BT_HFP_AG_ENABLED                CONFIG_BT_HFP_AG_ENABLE

--- a/components/bt/host/bluedroid/common/include/common/bt_target.h
+++ b/components/bt/host/bluedroid/common/include/common/bt_target.h
@@ -1551,12 +1551,17 @@
 #endif /* defined(HID_DEV_INCLUDED) && (HID_DEV_INCLUDED==TRUE) */
 #endif
 
-#ifndef SDP_MAX_PAD_LEN
+/* The maximum length, in bytes, of all SDP attributes combined. */
+#if defined(UC_SDP_MAX_PAD_LEN)
+#define SDP_MAX_PAD_LEN             UC_SDP_MAX_PAD_LEN
+#elif !defined(SDP_MAX_PAD_LEN)
 #define SDP_MAX_PAD_LEN             300
 #endif
 
 /* The maximum length, in bytes, of an attribute. */
-#ifndef SDP_MAX_ATTR_LEN
+#if defined(UC_SDP_MAX_ATTR_LEN)
+#define SDP_MAX_ATTR_LEN            UC_SDP_MAX_ATTR_LEN
+#elif !defined(SDP_MAX_ATTR_LEN)
 #define SDP_MAX_ATTR_LEN            400
 #endif
 


### PR DESCRIPTION
- There are a few use cases where the HID descriptor will easily exceed 250-300 bytes, especially with compound devices.
- The default attribute size is smaller than the maximum allowable size for all attributes. This is resolved with this feature.
- There isn't currently a way to allow larger SDP records even though the Bluetooth specification allows for it.
