### PR TITLE
feat(bt): PM override weak definition

### DIFF
--- a/components/bt/host/bluedroid/stack/btm/btm_pm.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_pm.c
@@ -739,6 +739,16 @@ void btm_pm_proc_cmd_status(UINT8 status)
     btm_pm_check_stored();
 }
 
+__attribute__((weak))
+void btm_hcif_mode_change_cb(BOOLEAN succeeded, UINT16 hci_handle, UINT8 mode, UINT16 interval)
+{
+    // This is the weak implementation, which will be overwritten
+    (void) succeeded;
+    (void) hci_handle;
+    (void) mode;
+    (void) interval;
+}
+
 /*******************************************************************************
 **
 ** Function         btm_process_mode_change
@@ -755,6 +765,12 @@ void btm_pm_proc_cmd_status(UINT8 status)
 *******************************************************************************/
 void btm_pm_proc_mode_change (UINT8 hci_status, UINT16 hci_handle, UINT8 mode, UINT16 interval)
 {
+    bool success = (hci_status == HCI_SUCCESS) ? true : false;
+    /* Custom HHL Code Callback */
+    btm_hcif_mode_change_cb(success, hci_handle, mode, interval);
+    // test not using the rest
+    return;
+    
     tACL_CONN   *p;
     tBTM_PM_MCB *p_cb = NULL;
     int yy;


### PR DESCRIPTION
Right now, the power management callback seems broken and causes disconnects with HID devices. This allows handling these changes manually.
